### PR TITLE
adds compiler output filtering, machine readable output, and absolute paths

### DIFF
--- a/builds/buildcommand.py
+++ b/builds/buildcommand.py
@@ -12,10 +12,67 @@ class BuildCommand:
         self.outfile = outfile
         self.displayName = displayName
         self.success = False
-    
+
+    def process_message(self, message, pipeline_configuration):
+        tag_error = 'error:'
+        tag_warning = 'warning:'
+        tag_hint = 'required from here'
+        if pipeline_configuration.get('machine-readable', False):
+            lines = message.split("\n")
+            output = []
+            for line in lines:
+                out = False
+                for tag in [tag_error, tag_warning]:
+                    tag_pos = line.find(tag)
+                    if tag_pos == -1:
+                        continue
+                    message_pos = tag_pos + len(tag)
+                    while line[message_pos].isspace():
+                        message_pos = message_pos + 1
+                    faux_tag_pos = tag_pos
+                    while True:
+                        if faux_tag_pos < 0:
+                            break
+                        c = line[faux_tag_pos]
+                        if c == ':':
+                            tag_pos = faux_tag_pos
+                            break
+                        if c.isdigit():
+                            tag_pos = faux_tag_pos + 1
+                            break
+                        faux_tag_pos = faux_tag_pos - 1
+                    if tag == tag_error:
+                        out = "error"
+                    if tag == tag_warning:
+                        out = "warning"
+                    out = out + " " + line[0:tag_pos] + " " + line[message_pos:len(line)]
+                    break
+                if out != False:
+                    output.append(out)
+            message = "\n".join(output)
+        elif pipeline_configuration.get('verbose', False):
+            message = message.replace('error', colored('error', 'red'))
+        else:
+            lines = message.split("\n")
+            output = []
+            for line in lines:
+                tag_error_pos = line.find(tag_error)
+                if tag_error_pos == -1:
+                    tag_error_pos = line.find(tag_warning)
+                if tag_error_pos == -1:
+                    tag_error_pos = line.find(tag_hint)
+                if tag_error_pos == -1:
+                    continue
+                output.append(line)
+            message = "\n".join(output)
+            message = message.replace('error', colored('error', 'red'))
+            message = message.replace('warning', colored('warning', 'yellow'))
+        return message
+
     def run(self, pipeline_configuration):
         verbose = pipeline_configuration.get('verbose', False)
         rebuild = pipeline_configuration.get('rebuild', False)
+        machine_readable = pipeline_configuration.get('machine-readable', False)
 
         if self.infile != self.outfile and not rebuild and os.path.isfile(self.infile) and os.path.isfile(self.outfile):
             in_mtime = os.path.getmtime(self.infile)
@@ -24,7 +81,10 @@ class BuildCommand:
                 self.success = True
                 return True
 
-        print(colored(self.commandtype, 'green') + ' ' + self.displayName)
+        if machine_readable:
+            print(self.commandtype + ' ' + self.displayName)
+        else:
+            print(colored(self.commandtype, 'green') + ' ' + self.displayName)
 
         try:
             if verbose:
@@ -41,9 +101,12 @@ class BuildCommand:
             self.success = True
 
         except subprocess.CalledProcessError as e:
-            print(colored(self.commandtype + ' failed', 'red'))
+            if machine_readable:
+                print(self.commandtype + '-failed')
+            else:
+                print(colored(self.commandtype + ' failed', 'red'))
             message = e.stderr.decode("utf-8")
         if message:
-            message = message.replace('error', colored('error', 'red'))
+            message = self.process_message(message, pipeline_configuration)
             print(message)
         return self.success

--- a/builds/builds.py
+++ b/builds/builds.py
@@ -202,7 +202,9 @@ def add_library(args, path):
     lib_paths = build_settings.get('library-paths')
 
     # Add path if it is valid
-    if path and os.path.isdir('./' + path):
+    if path[0] != "/":
+        path = "./" + path
+    if path and os.path.isdir(path):
         if path not in lib_paths:
             lib_paths.append(path)
             print(colored('+ path ', 'green') + path)
@@ -225,7 +227,7 @@ def add_library(args, path):
 @builds.command('add-shared-library')
 @click.argument('args', nargs=-1, type=str)
 @click.option('path', '-p', default='', help='Add shared library path along with the library')
-def add_library(args, path):
+def add_shared_library(args, path):
 
     # Figure out correct variables
     default_project = active_configuration.setdefault('default_project', 'default')
@@ -236,7 +238,9 @@ def add_library(args, path):
     slib_paths = build_settings.get('shared-library-paths')
 
     # Add path if it is valid
-    if path and os.path.isdir('./' + path):
+    if path[0] != "/":
+        path = "./" + path
+    if path and os.path.isdir(path):
         if path not in slib_paths:
             slib_paths.append(path)
             print(colored('+ path ', 'green') + path)
@@ -269,7 +273,9 @@ def add_include(args):
 
     # Add path if it is valid
     for path in args:
-        if path and os.path.isdir('./' + path):
+        if path[0] != "/":
+            path = "./" + path
+        if path and os.path.isdir(path):
             if path not in inc_paths:
                 inc_paths.append(path)
                 print(colored('+ path ', 'green') + path)

--- a/builds/builds.py
+++ b/builds/builds.py
@@ -343,10 +343,11 @@ def remove(files):
 @click.option('target', '--target', default='debug', help='Select target to build (debug/release)')
 @click.option('verbose', '--verbose', flag_value=True, help='Verbose command output')
 @click.option('rebuild', '--rebuild', flag_value=True, help='Clean and re-build .o files')
+@click.option('machine', '--machine', flag_value=True, help='Machine-readable compiler messages')
 @click.option('jobs', '--jobs', default=multiprocessing.cpu_count(),
               help='Run commands in parallel with x amount of jobs')
 @click.option('run', '--run', flag_value=True, help='Run executable output after building')
-def build(project_name, target, verbose, rebuild, jobs, run):
+def build(project_name, target, verbose, rebuild, machine, jobs, run):
     """This builds the selected project with the current settings in BUILDSFILENAME file. 
     Selected project defaults to the currently active project set in the BUILDSFILENAME file."""
 
@@ -381,6 +382,7 @@ def build(project_name, target, verbose, rebuild, jobs, run):
         'jobs' : jobs,
         'verbose' : verbose,
         'rebuild' : rebuild,
+        'machine-readable' : machine,
         'libraries' : project_libraries,
         'library-paths' : project_library_paths,
         'shared-library-paths' : project_shared_library_paths,
@@ -408,8 +410,8 @@ def build(project_name, target, verbose, rebuild, jobs, run):
             click.echo(colored('run', 'green') + " " + project_name)
             os.system("./"+project_name)
         stepsFinished += 1
-
-    click.echo('Finished ' + str(stepsFinished) + ' steps')
+    if not machine:
+        click.echo('Finished ' + str(stepsFinished) + ' steps')
 
 
 @builds.command('watch')


### PR DESCRIPTION
compiler output filtering:
 - **changes default behavior**: compiler output only shows errors, warnings, and hints
 - full compiler output (previous behavior) is given with `--verbose`.

machine readable output mode:
 - activated by `--machine`.
 - formats all outputs as `event-type <event-data> [more-event-data ...]` lines.

absolute path handling:
 - library and include paths that start with "/" will not have the "./" prefix added 
 - **incomplete solution**: the "/" check should be replaced with something cross platform